### PR TITLE
FIXED #300, #279, #303, #305-309

### DIFF
--- a/md/Compact Strategy for Squashed Audit Commits.md
+++ b/md/Compact Strategy for Squashed Audit Commits.md
@@ -1,0 +1,227 @@
+
+# ✅ Compact Strategy for Squashed Audit Commits
+
+This page that should render cleanly in GitHub Markdown, VS Code, and static guide engines like MkDocs or Docusaurus:
+
+---
+
+## 📝 Example Commit Message Template
+
+```text
+Audit updates #299–#305
+```
+
+- Concise, readable, grep-friendly  
+- Sufficient context for private or single-user workflows  
+- Use task range only when applicable  
+
+---
+
+## 🛠️ Context: Demo Simplest Implementation Using GitHub Desktop + Git CLI
+
+Since GitHub Desktop doesn't support squash merges directly, use the following workflow:
+
+### 🔧 Step-by-Step
+
+1. **Open the terminal for your repo**  
+   GitHub Desktop: `Repository > Open in Terminal`
+
+2. **Run this to squash the last N commits**  
+   Replace `N` with the desired number:
+
+   ```bash
+   git reset --soft HEAD~N
+   git commit -m "Audit updates #299–#305"
+   ```
+
+3. **Push the new single commit using GitHub Desktop**
+
+---
+
+## 📌 Example
+
+You made 4 audit commits locally:
+
+```bash
+git reset --soft HEAD~4
+git commit -m "Audit updates #312–#315"
+```
+
+Result: One tidy upstream commit after push.
+
+---
+
+## 🧩 Fixing Issues #289, #290, #291
+
+### 🌿 1. Create a New Branch
+
+Use GitHub Desktop:
+
+```text
+Branch > New Branch
+```
+
+- Name: `fix-audit-issues-289-291`  
+- Click `Create Branch`
+
+---
+
+### 🧪 2. Implement Fixes with Separate Commits
+
+For each issue:
+
+1. Make edits for the fix  
+2. In GitHub Desktop: `Changes` tab  
+3. Commit message:  
+
+   ```text
+   Fix issue #289: [brief description]
+   ```
+
+4. Commit to `fix-audit-issues-289-291`
+
+Repeat for:
+
+- Fix for #290  
+- Fix for #291  
+
+---
+
+### 🔀 3. Squash the Audit Commits
+
+Open the terminal:
+
+```bash
+git reset --soft HEAD~3
+git commit -m "Audit updates #289–#291"
+```
+
+---
+
+### 🚀 4. Push Changes
+
+In GitHub Desktop:
+
+```text
+Branch > Push Origin
+```
+
+---
+
+### 🔁 5. Create a Pull Request
+
+GitHub Desktop:
+
+```text
+Branch > Create Pull Request
+```
+
+- Title and description should link to issues #289, #290, and #291  
+- Click `Create Pull Request`
+
+---
+
+## 🧩 Context: Active Branch `Sq274`
+
+This branch carries the FIXED entry for #274, visible in the changelog block. There are other commits also FIXED for different tasks.
+
+The final result can be seen here: <https://github.com/adaept/aeBibleClass/commit/47faa142c479a485167755cef65eb87290399504>
+
+---
+
+### 🔧 Squash Merge Workflow (Audit-Friendly)
+
+#### 1. **Working on Sq274 in GitHub Desktop**
+
+This branch will have a number of commits until it is ready to be processed for upstream audit log creation.
+
+Current Status of Change Log:
+
+``` Text
+' FIXED - #302 - Update PrintCompactSectionLayoutInfo to output in rpt folder, move to basTESTaeBibleTools and add doc header
+' FIXED - #301 - 999 AppendToFile should be "SKIPPED" [bug]
+'Sq ' FIXED - #274 - Fix output path so 'Style Usage Distribution.txt' goes to rpt folder, add code header [bug] [doc]
+```
+
+The line with `'Sq` indicates the start of tasks to be squashed and merged.
+
+#### 1.1 **Review and Consolidate Commits**
+
+Before pushing squashed changes upstream, ensure the following:
+
+- Review all commits in the branch to confirm they align with the intended scope of the task.  
+- Consolidate related commits into a single, meaningful commit message that reflects the purpose of the changes.  
+- Use GitHub Desktop to squash commits via the Pull Request workflow (manual squash not required).
+
+#### 2. **Push Squashed Changes Upstream**
+
+### 🔍 Step-by-Step: Squash for Audit Readiness
+
+- Open the branch (`Sq274`) in GitHub Desktop and navigate to the **History** tab.  
+- Review each commit to ensure it relates to the same task or changelog block.  
+- Let the PR process handle the squash automatically—no manual squash needed.  
+- In the **PR description**, write a concise summary of the consolidated change, using language that aligns with the audit log style.
+
+🪶 Example:
+
+**FIXED #274, #301, #302, 304** – Summary
+
+**Extended Message Box:**  
+FIXED - #304 - Add task type [wip] - it will prepend the task commits until replaced by FIXED
+FIXED - #302 - Update PrintCompactSectionLayoutInfo to output in rpt folder, move to basTESTaeBibleTools and add doc header  
+FIXED - #301 - 999 AppendToFile should be "SKIPPED" [bug]  
+FIXED - #274 - Fix output path so 'Style Usage Distribution.txt' goes to rpt folder, add code header [bug] [doc]
+
+#### 3. **Pull Request to Main**
+
+- Create a PR from your local branch `Sq274` pushed to the remote repository on GitHub (`origin/Sq274`) targeting the remote `main` branch.  
+- The PR compares the remote `Sq274` branch against the remote `main`, with squash handled server-side.  
+- Carefully draft the title and description to reflect the consolidated task-level updates.
+
+#### 4. **Merge with Squash Confirmed**
+
+- Use "Squash and merge" in the PR UI to retain your audit-ready message.  
+- Final commit in `main` should reflect the full summary and task identifiers for clarity.
+
+---
+
+### 🧭 Where to Find It
+
+- After pushing your local branch (`Sq274`) to GitHub and opening a PR targeting `main`, scroll down to the **bottom of the PR page**.
+- If there are no conflicts and all required checks pass (e.g., CI/CD, review approvals), GitHub displays a green **“Merge pull request”** button.
+- Just above or beside that, there’s a dropdown arrow with merge strategy options.
+
+Click the dropdown—then select:
+
+> ✅ **Squash and merge**  
+> 🔁 Consolidates all commits into one before merging to `main`, using your drafted title and description.
+
+---
+
+### 🧪 What You Control
+
+- You’ll be prompted to **edit the final commit message** before confirming the merge.
+
+This is your moment to paste the audit-friendly message from your changelog block.
+
+---
+
+#### 5. **Post-Merge Local Cleanup (GitHub Desktop Only)**
+
+After completing the squash merge in GitHub, perform these post-merge steps using GitHub Desktop:
+
+1. **Delete Local Branch `Sq274`**
+   - Open **Branches** tab in GitHub Desktop.
+   - Right-click on `Sq274` → **Delete Branch**.
+
+2. **Sync Local `main` with Remote**
+   - Switch to the `main` branch.
+   - Click **Fetch Origin** → then **Pull Origin**.
+
+3. **Verify Local History**
+   - Go to the **History** tab.
+   - Confirm latest commits match remote `main`.
+
+4. **Optional: Housekeeping**
+   - Review stale branches in **Branches** tab.
+   - Delete unused ones if desired.

--- a/md/FIXED_AuditLog.md
+++ b/md/FIXED_AuditLog.md
@@ -1,5 +1,42 @@
 # Audits for Commit Log
 
+## [#301] AppendToFile should be "SKIPPED" [bug]
+
+- **Fixed in:** [`47faa14`](https://github.com/adaept/aeBibleClass/commit/47faa142c479a485167755cef65eb87290399504)
+- **File:** `basChangeLogaeBibleClass.bas`
+- **Line:** [L185](https://github.com/adaept/aeBibleClass/blob/fcc07412eddc3c3498affa5c0955c1a3db0a9779/src/basChangeLogaeBibleClass.bas#L185)
+- **Summary:** Corrected mislabeling of AppendToFile output; SKIPPED now outputs cleanly during session when required.
+- **Audit Result:** ✅ `[OK] Logic fix verified via commit message and diagnostic trail`
+
+---
+
+## [#302] Move PrintCompactSectionLayoutInfo to basTESTaeBibleTools and update output path
+
+- **Fixed in:** [`47faa14`](https://github.com/adaept/aeBibleClass/commit/47faa142c479a485167755cef65eb87290399504)
+- **File:** `basTESTaeBibleTools.bas`
+- **Line:** [L1](https://github.com/adaept/aeBibleClass/blob/fcc07412eddc3c3498affa5c0955c1a3db0a9779/src/basTESTaeBibleTools.bas#L1)
+- **Summary:** Relocated macro for compact section layout reporting; updated output path to `rpt` folder and added header for audit context.
+- **Audit Result:** ✅ `[OK] Macro relocation and output path audit confirmed`
+
+---
+
+## [#304] Add task type [wip] for pre-resolution changelog tagging
+
+- **Fixed in:** [`47faa14`](https://github.com/adaept/aeBibleClass/commit/47faa142c479a485167755cef65eb87290399504)
+- **File:** `basChangeLogaeBibleClass.bas`
+- **Line:** [L187](https://github.com/adaept/aeBibleClass/blob/fcc07412eddc3c3498affa5c0955c1a3db0a9779/src/basChangeLogaeBibleClass.bas#L187)
+- **Summary:** Introduced `[wip]` task type for early commit tagging—enables staging of partial fixes without audit disruption.
+- **Audit Result:** ✅ `[OK] Task type logic operational and format-compatible`
+
+## [#274] Fix output path so 'Style Usage Distribution.txt' goes to rpt folder, add code header
+
+- **Fixed in:**
+  - [`47faa14`](https://github.com/adaept/aeBibleClass/commit/47faa142c479a485167755cef65eb87290399504)
+- **File:** `basChangeLogaeBibleClass.bas`
+- **Line:** [L12](https://github.com/adaept/aeBibleClass/blob/fcc07412eddc3c3498affa5c0955c1a3db0a9779/src/basChangeLogaeBibleClass.bas#L12)
+- **Summary:** Updated output path logic and added documentation header for style usage report.
+- **Audit Result:** ✅ `[OK] #274 found within module block`
+
 ## [#299] Final validator update and audit format clarification
 
 - **Fixed in:** [`ff2aa10`](https://github.com/adaept/aeBibleClass/commit/ff2aa102a1aabcd00f330c6475693527ff79c200)
@@ -33,7 +70,7 @@
 - **File:** `basChangeLogaeBibleClass.bas`
 - **Line:** [L12](https://github.com/adaept/aeBibleClass/blob/fcc07412eddc3c3498affa5c0955c1a3db0a9779/src/basChangeLogaeBibleClass.bas#L12)
 - **Summary:** Refactored changelog entry and implemented SSOT logic with Select Case validation.
-- **Audit Result:** `[OK] #298 found within module block`
+- **Audit Result:** ✅ `[OK] #298 found within module block`
 
 ## [#297] Create file to hold Audits for Commit Log
 
@@ -43,7 +80,7 @@
 - **File:** `basChangeLogaeBibleClass.bas`
 - **Line:** [L14](https://github.com/adaept/aeBibleClass/blob/fcc07412eddc3c3498affa5c0955c1a3db0a9779/src/basChangeLogaeBibleClass.bas#L14)
 - **Summary:** Added FIXED_AuditLog.md and updated changelog to include task #297.
-- **Audit Result:** `[OK] #297 found within module block`
+- **Audit Result:** ✅ `[OK] #297 found within module block`
 
 ## [#296] ValidateTaskInChangelogModule
 
@@ -51,4 +88,4 @@
 - **File:** `basChangeLogaeBibleClass.bas`
 - **Line:** [L14](https://github.com/adaept/aeBibleClass/blob/fcc07412eddc3c3498affa5c0955c1a3db0a9779/src/basChangeLogaeBibleClass.bas#L14)
 - **Summary:** Added validation macro to confirm task tags appear within changelog blocks.
-- **Audit Result:** `[OK] #296 found within module block`
+- **Audit Result:** ✅ `[OK] #296 found within module block`

--- a/rpt/TestReport.txt
+++ b/rpt/TestReport.txt
@@ -54,14 +54,14 @@ PASS              Copy ()       Test = 47     2             2             CountT
 FAIL!!!!          Copy ()       Test = 48     1             0             AuditLiberationSansNarrowStyleDetails
 PASS              Copy ()       Test = 49     16            16            CountAuditStyles_ToFile
 PASS              Copy ()       Test = 50     147           147           SummarizeHeaderFooterAuditToFile
-Total Total Runtime: 162.89 seconds
-[2025-07-29 18:00:05] Completed
+Total Total Runtime: 98.93 seconds
+[2025-08-02 12:39:37] Completed
 BibleClass VERSION: 0.1.0
 BibleClass VERSION_DATE: July 19, 2025
 == Word Build Info ==
 Application Name: Microsoft Word
 Platform Version: 16.0
-Platform Build: 16.0.18925
-Full Version String: Microsoft Word 16.0 (16.0.18925)
+Platform Build: 16.0.19029
+Full Version String: Microsoft Word 16.0 (16.0.19029)
 Marketing Version: 2506 (Build 18925.20158)
 Source: Microsoft 365 Current Channel, July 2025 update

--- a/src/Module1.bas
+++ b/src/Module1.bas
@@ -7,12 +7,6 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
 
 Public Const wdThemeColorNone As Long = -1
 Public Const wdPaperB5Jis As Integer = 11
-Private Sections1Col As Integer
-Private Sections2Col As Integer
-Private SectionsOddPageBreaks As Integer
-Private SectionsEvenPageBreaks As Integer
-Private SectionsContinuousBreaks As Integer
-Private SectionsNewPageBreaks As Integer
 
 Sub ViewCodeDetails()
     Dim selectedText As String
@@ -741,110 +735,6 @@ Function GetVerticalAlignmentName(valign As WdVerticalAlignment) As String
     End Select
 End Function
 
-Sub PrintCompactSectionLayoutInfo()
-    Dim sec As section
-    Dim i As Long
-    Dim nOneCol As Long, nTwoCol As Long
-    Dim nEvenPageBreak As Long, nOddPageBreak As Long
-    Dim nContinuousBreak As Long, nNewPageBreak As Long
-    Dim outputFile As String
-    Dim outputText As String
-    outputFile = "C:\adaept\aeBibleClass\DocumentLayoutReport.txt"  ' Change to your desired path
-
-    ' Open the text file to write
-    Open outputFile For Output As #1
-    
-    ' Write Header to the file
-    outputText = "=== Layout Report ===" & vbCrLf
-    outputText = outputText & "Doc: " & ActiveDocument.name & vbCrLf
-    outputText = outputText & "Total Sections: " & ActiveDocument.Sections.count & vbCrLf & vbCrLf
-    Print #1, outputText
-    
-    For i = 1 To ActiveDocument.Sections.count
-        Set sec = ActiveDocument.Sections(i)
-        
-        outputText = "Section " & i & ": " & vbCrLf
-        outputText = outputText & "Page: " & IIf(sec.pageSetup.orientation = wdOrientPortrait, "Portrait", "Landscape") & ", " & _
-                    "Size: " & GetPaperSizeName(sec.pageSetup.paperSize) & ", " & _
-                    "Columns: " & sec.pageSetup.TextColumns.count & vbCrLf
-        If sec.pageSetup.TextColumns.count > 1 Then nTwoCol = nTwoCol + 1 Else nOneCol = nOneCol + 1
-        
-        ' Margins
-        outputText = outputText & "Margins (inches): " & _
-                    "Top: " & PointsToInches(sec.pageSetup.topMargin) & ", " & _
-                    "Bottom: " & PointsToInches(sec.pageSetup.bottomMargin) & ", " & _
-                    "Left: " & PointsToInches(sec.pageSetup.leftMargin) & ", " & _
-                    "Right: " & PointsToInches(sec.pageSetup.rightMargin) & ", " & _
-                    "Gutter: " & PointsToInches(sec.pageSetup.gutter) & vbCrLf
-        
-        ' Line Numbering
-        If sec.pageSetup.LineNumbering.Active Then
-            outputText = outputText & "Line Numbers: " & sec.pageSetup.LineNumbering.StartingNumber & ", " & _
-                        "Increment: " & sec.pageSetup.LineNumbering.CountBy & vbCrLf
-        End If
-        
-        ' Header/Footer settings
-        outputText = outputText & "Header Distance: " & PointsToInches(sec.pageSetup.HeaderDistance) & ", " & _
-                    "Footer Distance: " & PointsToInches(sec.pageSetup.FooterDistance) & vbCrLf
-        
-        ' Borders (if any)
-        outputText = outputText & "Borders: " & _
-                    "Top: " & GetBorderStyle(sec.Borders(wdBorderTop)) & ", " & _
-                    "Bottom: " & GetBorderStyle(sec.Borders(wdBorderBottom)) & ", " & _
-                    "Left: " & GetBorderStyle(sec.Borders(wdBorderLeft)) & ", " & _
-                    "Right: " & GetBorderStyle(sec.Borders(wdBorderRight)) & vbCrLf
-        
-        ' Section Break Type
-        Select Case sec.pageSetup.sectionStart
-            Case wdSectionNewPage
-                outputText = outputText & "Section Break: New Page" & vbCrLf
-                nNewPageBreak = nNewPageBreak + 1
-            Case wdSectionOddPage
-                outputText = outputText & "Section Break: Odd Page" & vbCrLf
-                nOddPageBreak = nOddPageBreak + 1
-            Case wdSectionEvenPage
-                outputText = outputText & "Section Break: Even Page" & vbCrLf
-                nEvenPageBreak = nEvenPageBreak + 1
-            Case wdSectionContinuous
-                outputText = outputText & "Section Break: Continuous" & vbCrLf
-                nContinuousBreak = nContinuousBreak + 1
-            Case Else
-                outputText = outputText & "Section Break: None" & vbCrLf
-        End Select
-        
-        ' Write section data to file
-        Print #1, outputText
-        outputText = "" ' Reset outputText for the next section
-    Next i
-    
-    ' Summary of Sections
-    outputText = "Summary: " & vbCrLf
-    outputText = outputText & "Sections with 1 Column: " & nOneCol & vbCrLf
-    Sections1Col = nOneCol
-    Debug.Print "Sections1Col = " & nOneCol
-    outputText = outputText & "Sections with 2 Columns: " & nTwoCol & vbCrLf
-    Sections2Col = nTwoCol
-    Debug.Print "Sections2Col = " & nTwoCol
-    outputText = outputText & "Sections with Odd Page Breaks: " & nOddPageBreak & vbCrLf
-    SectionsOddPageBreaks = nOddPageBreak
-    Debug.Print "SectionsOddPageBreaks = " & nOddPageBreak
-    outputText = outputText & "Sections with Even Page Breaks: " & nEvenPageBreak & vbCrLf
-    SectionsEvenPageBreaks = nEvenPageBreak
-    Debug.Print "SectionsEvenPageBreaks = " & nEvenPageBreak
-    outputText = outputText & "Sections with Continuous Breaks: " & nContinuousBreak & vbCrLf
-    SectionsContinuousBreaks = nContinuousBreak
-    Debug.Print "SectionsContinuousBreaks = " & nContinuousBreak
-    outputText = outputText & "Sections with New Page Breaks: " & nNewPageBreak & vbCrLf
-    SectionsNewPageBreaks = nNewPageBreak
-    Debug.Print "SectionsNewPageBreaks = " & nNewPageBreak
-    Print #1, outputText
-    
-    ' Close the file
-    Close #1
-
-    'MsgBox "Layout report saved to: " & outputFile, vbInformation
-End Sub
-
 Function PointsToInches(Points As Single) As String
     PointsToInches = Format(Points / 72, "0.00")
 End Function
@@ -1068,5 +958,134 @@ Function IsFootnoteRefFormattedCorrectly(rng As range) As Boolean
             And .Superscript = True
     End With
 End Function
+
+Sub TestPageRangeEnd()
+    Selection.GoTo What:=wdGoToPage, name:="70"
+    Selection.MoveRight Unit:=wdCharacter, count:=1
+    Dim pageEnd As Long
+    pageEnd = Selection.Bookmarks("\Page").range.End
+    Selection.GoTo What:=wdGoToPage, name:="71"
+    Selection.MoveRight Unit:=wdCharacter, count:=1
+    Dim page71Start As Long
+    page71Start = Selection.Start
+    Debug.Print "Page 70 ends at: " & pageEnd
+    Debug.Print "Page 71 starts at: " & page71Start
+End Sub
+
+Sub AuditFontUsage_ParagraphsAndHeadersFooters()
+    Dim para As paragraph
+    Dim fontMap As Object
+    Dim fName As String
+    Dim keyVar As Variant
+    Dim logBuffer As String
+    Dim sec As section
+    Dim hf As HeaderFooter
+    Dim hfTypes As Variant
+    Dim hfKind As Variant
+
+    Set fontMap = CreateObject("Scripting.Dictionary")
+
+    ' Scan body paragraphs
+    For Each para In ActiveDocument.paragraphs
+        fName = para.range.Characters(1).font.name
+        If Not fontMap.Exists(fName) Then
+            fontMap.Add fName, 1
+        Else
+            fontMap(fName) = fontMap(fName) + 1
+        End If
+    Next para
+
+    ' Define header/footer types
+    hfTypes = Array(wdHeaderFooterPrimary, wdHeaderFooterFirstPage, wdHeaderFooterEvenPages)
+
+    ' Scan header/footer paragraphs
+    For Each sec In ActiveDocument.Sections
+        For Each hfKind In hfTypes
+            Set hf = sec.Headers(hfKind)
+            If hf.Exists Then
+                For Each para In hf.range.paragraphs
+                    fName = para.range.Characters(1).font.name
+                    If Not fontMap.Exists(fName) Then
+                        fontMap.Add fName, 1
+                    Else
+                        fontMap(fName) = fontMap(fName) + 1
+                    End If
+                Next para
+            End If
+
+            Set hf = sec.Footers(hfKind)
+            If hf.Exists Then
+                For Each para In hf.range.paragraphs
+                    fName = para.range.Characters(1).font.name
+                    If Not fontMap.Exists(fName) Then
+                        fontMap.Add fName, 1
+                    Else
+                        fontMap(fName) = fontMap(fName) + 1
+                    End If
+                Next para
+            End If
+        Next hfKind
+    Next sec
+
+    ' Output results
+    logBuffer = "=== Font Usage Across Body, Headers, and Footers ===" & vbCrLf
+    For Each keyVar In fontMap.Keys
+        logBuffer = logBuffer & "- " & keyVar & ": " & fontMap(keyVar) & " paragraph(s)" & vbCrLf
+    Next
+
+    Debug.Print logBuffer
+    MsgBox "Full font audit complete. See Immediate Window.", vbInformation
+End Sub
+
+Public Sub xxxRunTestCase(ByVal intTestIndex As Integer)
+    Dim dblStart As Double, dblEnd As Double
+    Dim varActualResult As Variant, varExpectedResult As Variant
+    Dim varOutcome As String, varRuntime As Double
+    'Dim objTest As aeTestResult
+    'Set objTest = New aeTestResult
+
+    Select Case intTestIndex
+        Case 9
+            Debug.Print "Running Test 9: CountPeriodSpaceLeftParenthesis"
+            dblStart = Timer
+
+            'varActualResult = CountPeriodSpaceLeftParenthesis()
+            varExpectedResult = 7
+            varOutcome = IIf(varActualResult = varExpectedResult, "PASS", "FAIL")
+
+            dblEnd = Timer
+            varRuntime = Round(dblEnd - dblStart, 2)
+
+            Debug.Print varOutcome, vbTab, "Copy ()", vbTab, _
+                        "Test = 9", vbTab, varActualResult, vbTab, _
+                        varExpectedResult, vbTab, "CountPeriodSpaceLeftParenthesis"
+            Debug.Print "Routine Runtime:", Format(varRuntime, "0.00"), "seconds"
+
+            'With objTest
+            '    .Index = 9
+            '    .FunctionName = "CountPeriodSpaceLeftParenthesis"
+            '    .ActualResult = varActualResult
+            '    .ExpectedResult = varExpectedResult
+            '    .Outcome = varOutcome
+            '    .RoutineRuntimeSeconds = varRuntime
+            'End With
+
+        Case 10 To 12 ' Dummy scaffolds—extend when needed
+            'objTest.Index = intTestIndex
+            'objTest.FunctionName = "Function_" & intTestIndex
+            'objTest.ExpectedResult = 0
+            'objTest.ActualResult = 0
+            'objTest.Outcome = "PASS"
+            'objTest.RoutineRuntimeSeconds = 0.25 ' Stub time
+            'Debug.Print "Test", intTestIndex, "executed (dummy scaffold)"
+
+        Case Else
+            Debug.Print "Test index not recognized:", intTestIndex
+    End Select
+
+    ' Optionally save objTest to an array or export structure here
+
+End Sub
+
 
 

--- a/src/aeBibleClass.cls
+++ b/src/aeBibleClass.cls
@@ -1111,7 +1111,7 @@ Private Function SummarizeHeaderFooterAuditToFile()
     ' Output to file based on validation
     If headerOk And footerOk Then
         ts.WriteLine "--- ASCII Value Counts and Descriptions ---"
-        Dim key
+        Dim key As Variant
         For Each key In dictAsciiCount.Keys
             ts.WriteLine "ASCII=" & key & _
                 " | Count=" & dictAsciiCount(key) & _

--- a/src/aeBibleClass.cls
+++ b/src/aeBibleClass.cls
@@ -191,13 +191,15 @@ Private Sub Expected1BasedArray()
         Exit Sub
     End If
 
-    Set doc = ActiveDocument
-    TestReportFileName = doc.Path & "\rpt\TestReport.txt"
-      
-    ' Open the debug file for writing
-    testFileNum = FreeFile
-    Open TestReportFileName For Output As testFileNum
-    Close testFileNum
+    If OneTest = 0 Then
+        ' Do not make new TestReportFileName for single tests
+        Set doc = ActiveDocument
+        TestReportFileName = doc.Path & "\rpt\TestReport.txt"
+        ' Open the debug file for writing
+        testFileNum = FreeFile
+        Open TestReportFileName For Output As testFileNum
+        Close testFileNum
+    End If
     
     ' Define the Expected RunTest result values to store in the array
     '      RunTest 1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16    17  18  19 20 21 22   23 24    25 26 27   28  29  30 31 32   33   34   35   36 37  38   39 40 41 42 43 44 45 46 47 48 49  50)

--- a/src/aeBibleClass.cls
+++ b/src/aeBibleClass.cls
@@ -45,7 +45,6 @@ Private Const vbext_ct_Document As Long = 100
 Private Const wdNotThemeColor As Long = -1
 ' Default use is to not time all tests individually
 Private Const bTimeAllTests As Boolean = True
-Private Const bGoTo16 As Boolean = False
 ' Used to store Expected results
 Private oneBasedExpectedArray As Variant
 Private Const MaxTests = 50
@@ -129,14 +128,14 @@ Private Sub InitializeGlobalResultArrayToMinusOne()
 
     On Error GoTo PROC_ERR
 
-1    Dim i As Integer, j As Integer
-2    For i = 1 To MaxTests
-3        ResultArray(i) = -1
-4    Next i
-5    ' Session ID to be stored in TestTimingArray(0)
-6    For j = 0 To MaxTests
-7        TestTimingArray(j) = -1
-8    Next j
+    Dim i As Integer, j As Integer
+    For i = 1 To MaxTests
+        ResultArray(i) = -1
+    Next i
+    ' Session ID to be stored in TestTimingArray(0)
+    For j = 0 To MaxTests
+        TestTimingArray(j) = -1
+    Next j
     ' Optional: Print to Immediate window to confirm
     'For i = 1 To MaxTests
     '    Debug.Print "ResultArray(" & i & ") = " & ResultArray(i),
@@ -194,12 +193,7 @@ Private Sub Expected1BasedArray()
 
     Set doc = ActiveDocument
     TestReportFileName = doc.Path & "\rpt\TestReport.txt"
-    
-    ' Delete the old debug file if it exists
-    If Dir(TestReportFileName) <> "" Then
-        Kill TestReportFileName
-    End If
-    
+      
     ' Open the debug file for writing
     testFileNum = FreeFile
     Open TestReportFileName For Output As testFileNum
@@ -224,7 +218,7 @@ Private Sub Expected1BasedArray()
         outputString = Trim(outputString)
     Next i
     Debug.Print outputString
-    If TestReportFlag Then AppendToFile TestReportFileName, outputString
+    If TestReportFlag And OneTest = 0 Then AppendToFile TestReportFileName, outputString
     
     ' Next 15 results
     outputString = ""
@@ -234,7 +228,7 @@ Private Sub Expected1BasedArray()
         outputString = Trim(outputString)
     Next i
     Debug.Print outputString
-    If TestReportFlag Then AppendToFile TestReportFileName, outputString
+    If TestReportFlag And OneTest = 0 Then AppendToFile TestReportFileName, outputString
     
     ' Next results
     outputString = ""
@@ -244,7 +238,7 @@ Private Sub Expected1BasedArray()
         outputString = Trim(outputString)
     Next i
     Debug.Print outputString
-    If TestReportFlag Then AppendToFile TestReportFileName, outputString
+    If TestReportFlag And OneTest = 0 Then AppendToFile TestReportFileName, outputString
 
     ' Next results
     outputString = ""
@@ -254,7 +248,7 @@ Private Sub Expected1BasedArray()
         outputString = Trim(outputString)
     Next i
     Debug.Print outputString
-    If TestReportFlag Then AppendToFile TestReportFileName, outputString
+    If TestReportFlag And OneTest = 0 Then AppendToFile TestReportFileName, outputString
 
 PROC_EXIT:
     Exit Sub
@@ -353,23 +347,26 @@ Private Function RunBibleClassTests(Optional ByVal varDebug As Variant) As Boole
             On Error GoTo PROC_ERR
                         
             Call Expected1BasedArray
-            Debug.Print "1234567890123412345678901234123456789012341234567890123412345678901234"
-            '            123456789    1234567    12345678    123456    12345678    12345678     NOTE: Comma separation of debug is 14 characters
-            Debug.Print "Pass/Fail", "Copy ()", "Test Num", "Result", "Expected", "Function"
-            If TestReportFlag Then AppendToFile TestReportFileName, "1234567890123412345678901234123456789012341234567890123412345678901234"
-            If TestReportFlag Then AppendToFile TestReportFileName, "Pass/Fail" & space(5) & "Copy ()" & space(7) & "Test Num" & space(6) & "Result" & space(8) & "Expected" & space(6) & "Function"
             
             If OneTest <> 0 Then
                 'If OneTest = 42 Then
                 '    Call RunTest(OneTest, "SKIP")
                 '    Exit Function
                 'Else
+                    Debug.Print "1234567890123412345678901234123456789012341234567890123412345678901234"
+                    '            123456789    1234567    12345678    123456    12345678    12345678     NOTE: Comma separation of debug is 14 characters
+                    Debug.Print "Pass/Fail", "Copy ()", "Test Num", "Result", "Expected", "Function"
                     RunTest (OneTest)
                     Exit Function
                 'End If
             End If
             
-            If bGoTo16 Then GoTo Test16
+            Debug.Print "1234567890123412345678901234123456789012341234567890123412345678901234"
+            '            123456789    1234567    12345678    123456    12345678    12345678     NOTE: Comma separation of debug is 14 characters
+            Debug.Print "Pass/Fail", "Copy ()", "Test Num", "Result", "Expected", "Function"
+            If TestReportFlag And OneTest = 0 Then AppendToFile TestReportFileName, "1234567890123412345678901234123456789012341234567890123412345678901234"
+            If TestReportFlag And OneTest = 0 Then AppendToFile TestReportFileName, "Pass/Fail" & space(5) & "Copy ()" & space(7) & "Test Num" & space(6) & "Result" & space(8) & "Expected" & space(6) & "Function"
+            
             RunTest (1)
             RunTest (2)
             RunTest (3)
@@ -385,7 +382,7 @@ Private Function RunBibleClassTests(Optional ByVal varDebug As Variant) As Boole
             RunTest (13)
             RunTest (14)
             RunTest (15)
-Test16:     RunTest (16)
+            RunTest (16)
             RunTest (17)
             RunTest (18)
             RunTest (19)
@@ -435,18 +432,19 @@ Test16:     RunTest (16)
     ' Output the runtime in seconds and hundredths of a second
     'MsgBox "Runtime: " & Format(runTime, "0.00") & " seconds"
     Debug.Print "Total Total Runtime: " & Format(runTime, "0.00") & " seconds"
-    If TestReportFlag Then AppendToFile TestReportFileName, "Total Total Runtime: " & Format(runTime, "0.00") & " seconds"
+    If TestReportFlag And OneTest = 0 Then AppendToFile TestReportFileName, "Total Total Runtime: " & Format(runTime, "0.00") & " seconds"
     
     Debug.Print LogMessage("Completed")
-    If TestReportFlag Then AppendToFile TestReportFileName, LogMessage("Completed")
+    If TestReportFlag And OneTest = 0 Then AppendToFile TestReportFileName, LogMessage("Completed")
 
     Debug.Print "BibleClass VERSION: " & BibleClassVERSION
-    If TestReportFlag Then AppendToFile TestReportFileName, "BibleClass VERSION: " & BibleClassVERSION
+    If TestReportFlag And OneTest = 0 Then AppendToFile TestReportFileName, "BibleClass VERSION: " & BibleClassVERSION
+    
     Debug.Print "BibleClass VERSION_DATE: " & BibleClassVERSION_DATE
-    If TestReportFlag Then AppendToFile TestReportFileName, "BibleClass VERSION_DATE: " & BibleClassVERSION_DATE
+    If TestReportFlag And OneTest = 0 Then AppendToFile TestReportFileName, "BibleClass VERSION_DATE: " & BibleClassVERSION_DATE
 
     Debug.Print LogWordBuildInfo
-    If TestReportFlag Then AppendToFile TestReportFileName, LogWordBuildInfo
+    If TestReportFlag And OneTest = 0 Then AppendToFile TestReportFileName, LogWordBuildInfo
 
     RunBibleClassTests = True
 
@@ -665,163 +663,165 @@ Private Function RunTest(num As Integer, Optional SkipTest As Variant) As Boolea
     Select Case num
     Case 1
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountDoubleSpaces"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 2
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountDoubleSpacesInShapes"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 3
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountSpaceFollowedByCarriageReturn"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 4
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountDoubleTabs"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 5
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountWhiteSpaceAndCarriageReturn"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 6
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountQuadrupleParagraphMarks"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 7
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountStyleWithSpaceAndNumber"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 8
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountStyleWithNumberAndSpace"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 9
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountPeriodSpaceLeftParenthesis"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 10
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountNonBreakingSpaces"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 11
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountFindNumberDashNumber"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 12
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountNumberDashNumberInFootnotes"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 13
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountEmptyParasWithNoThemeColor"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 14
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountWhiteParagraphMarks"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 15
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountSectionsWithDifferentFirstPage"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 16
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountTotalParagraphs"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 17
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountRedFootnoteReferences"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 18
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountHeading1"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 19
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountEmptyParasAfterH2"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 20
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountFootnotesFollowedByDigit"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 21
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountNotSpacesAfterFootnoteReferences"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 22
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountEmptyParagraphsWithFormatting"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 23
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountDeleteEmptyParagraphsBeforeHeading2"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 24
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountFootnoteReferences"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 25
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountFootnoteReferenceColors"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 26
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CheckAllHeaders(" & "Empty" & ")"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 27
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CheckAllHeaders(" & "NotEmpty" & ")"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 28
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountTabFollowedByParagraphMarkInHeaders"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 29
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountParagraphsWithoutTabInHeaders"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 30
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountHeaderStyleUsage"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 31
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountParagraphMarksPerHeaderSection"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 32
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountLinefeed"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 33
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountLinefeed(" & """ """ & ")"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 34
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountManualLineBreaksAndWithSpace"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 35
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountManualLineBreaksAndWithSpace(" & """ """ & ")"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 36
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountFooterParagraphsWithFooterStyle"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 37
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountDocTabOnlyParagraphs"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 38
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountEmptyParagraphs"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 39
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountParagraphMarks_ArialBlack"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 40
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountParagraphMarks_ArialBlackDarkRed"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 41
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "Count_ArialBlack8pt_Normal_DarkRed_NotEmphasisRed"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 42
         If SkipTest = num Then
             Debug.Print GetPassFail(999), "Copy ()", "Test = " & num, -1, oneBasedExpectedArray(num), "CountBoldFootnotesWordLevel"
-            If TestReportFlag Then Call OutputTestReport(num, num)
+            If TestReportFlag And OneTest = 0 Then Call OutputTestReport(num, num)
         Else
-            If TestReportFlag Then OutputTestReport (num)
+            If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
             Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountBoldFootnotesWordLevel"
         End If
     Case 43
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountDarkRedStyledParagraphMarks"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 44
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountParagraphMarks_CalibriDarkRed"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 45
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountFindNotEmphasisBlack"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 46
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountFindNotEmphasisRed"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 47
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountTabOnlyParagraphs(" & """Footer""" & ")"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 48
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "AuditLiberationSansNarrowStyleDetails"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 49
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "CountAuditStyles_ToFile"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
     Case 50
         Debug.Print GetPassFail(num), "Copy ()", "Test = " & num, ResultArray(num), oneBasedExpectedArray(num), "SummarizeHeaderFooterAuditToFile"
-        If TestReportFlag Then OutputTestReport (num)
+        If TestReportFlag And OneTest = 0 Then OutputTestReport (num)
    Case Else
         Debug.Print "num = " & num & " >>The test number is outside the accepted range"
     End Select
 
+    'Debug.Print "OneTest = " & OneTest
+    
     endTime = Timer
     runTime = endTime - startTime
     
@@ -1209,12 +1209,11 @@ Private Function CountAuditStyles_ToFile() As Long
         Loop Until rng Is Nothing
     Next rng
 
-    ' Output to text file beside the document
     Dim fso As Object, outFile As Object, outputPath As String
     Set fso = CreateObject("Scripting.FileSystemObject")
     outputPath = fso.GetParentFolderName(ActiveDocument.FullName) & "\rpt\Style Usage Distribution.txt"
     Set outFile = fso.CreateTextFile(outputPath, True)
-    Debug.Print "outputPath = " & outputPath
+    'Debug.Print "outputPath = " & outputPath
 
     outFile.WriteLine "=== Style Usage Distribution ==="
     Dim key As Variant

--- a/src/basChangeLogaeBibleClass.bas
+++ b/src/basChangeLogaeBibleClass.bas
@@ -9,7 +9,6 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
 ' Tasks: [doc] [test] [bug] [perf] [audit] [disc] [feat] [idea] [impr] [flow] [cp] [code] [wip] [clean] [obso] [regr]
 ' #310 -
 ' #309 -
-' #303 - Fix single RUN_THE_TESTS(x) so it does not run AppendToFile and kill the full report [bug]
 ' #295 - Verify use of late binding in all code base so there is no need to set references [code]
 ' #294 - Cut a 0.1.1 release and tag it on GitHub [doc] [cp]
 ' #293 - Add md doc 'Bias Guard' to reduce hallucination (h13n) [doc] [cp]
@@ -71,6 +70,7 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
 ' #024 - ExtractNumbersFromParagraph2 using DoEvents. Still unresponsive after Genesis 50, fifth para [bug]
 '====================================================================================================================================
 '
+    ' FIXED - #303 - Fix single RUN_THE_TESTS(x) so it does not run AppendToFile and kill the full report [bug]
     ' FIXED - #305 - Check header writing standard, vbnet vs. vba, use style ' ============== [cp] [clean]
     ' [obso] #100 - Continue check multipage view from 300 for orphans of H2
     ' FIXED - #308 - Update all use of TestReportFlag to -> If TestReportFlag And OneTest = 0 [bug]

--- a/src/basChangeLogaeBibleClass.bas
+++ b/src/basChangeLogaeBibleClass.bas
@@ -9,8 +9,6 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
 ' Tasks: [doc] [test] [bug] [perf] [audit] [disc] [feat] [idea] [impr] [flow] [cp] [code] [wip] [clean] [obso] [regr]
 ' #310 -
 ' #309 -
-' #308 -
-' #307 -
 ' #305 - Check header writing standard, vbnet vs. vba [cp] [clean]
 ' #303 - Fix single RUN_THE_TESTS(x) so it does not run AppendToFile and kill the full report [bug]
 ' #295 - Verify use of late binding in all code base so there is no need to set references [code]
@@ -75,6 +73,8 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
 ' #024 - ExtractNumbersFromParagraph2 using DoEvents. Still unresponsive after Genesis 50, fifth para
 '====================================================================================================================================
 '
+    ' FIXED - #308 - Update all use of TestReportFlag to - If TestReportFlag And OneTest = 0
+    ' FIXED - #307 - Remove bGoTo16, not needed with use of run single test [obso] [clean]
     ' FIXED - #306 - Add audit log from squash #274 [doc] [audit]
     ' FIXED - #279 - Add routine to define H2 style and reapply it in the project, add code header [impr] [code]
 'Sq ' FIXED - #300 - Add md doc to outline a Compact Strategy for Squashed Audit Commits and reduce GitHub commit log spam

--- a/src/basChangeLogaeBibleClass.bas
+++ b/src/basChangeLogaeBibleClass.bas
@@ -7,8 +7,12 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
 
 '====================================================================================================================================
 ' Tasks: [doc] [test] [bug] [perf] [audit] [disc] [feat] [idea] [impr] [flow] [cp] [code] [wip] [clean] [obso] [regr]
+' #315 -
+' #314 -
+' #313 -
+' #312 -
+' #311 -
 ' #310 -
-' #309 -
 ' #295 - Verify use of late binding in all code base so there is no need to set references [code]
 ' #294 - Cut a 0.1.1 release and tag it on GitHub [doc] [cp]
 ' #293 - Add md doc 'Bias Guard' to reduce hallucination (h13n) [doc] [cp]
@@ -70,6 +74,7 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
 ' #024 - ExtractNumbersFromParagraph2 using DoEvents. Still unresponsive after Genesis 50, fifth para [bug]
 '====================================================================================================================================
 '
+    ' FIXED - #309 - Add code to scan modules in .docm to flag early-bound object declarations [code]
     ' FIXED - #303 - Fix single RUN_THE_TESTS(x) so it does not run AppendToFile and kill the full report [bug]
     ' FIXED - #305 - Check header writing standard, vbnet vs. vba, use style ' ============== [cp] [clean]
     ' [obso] #100 - Continue check multipage view from 300 for orphans of H2

--- a/src/basChangeLogaeBibleClass.bas
+++ b/src/basChangeLogaeBibleClass.bas
@@ -9,7 +9,6 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
 ' Tasks: [doc] [test] [bug] [perf] [audit] [disc] [feat] [idea] [impr] [flow] [cp] [code] [wip] [clean] [obso] [regr]
 ' #310 -
 ' #309 -
-' #305 - Check header writing standard, vbnet vs. vba [cp] [clean]
 ' #303 - Fix single RUN_THE_TESTS(x) so it does not run AppendToFile and kill the full report [bug]
 ' #295 - Verify use of late binding in all code base so there is no need to set references [code]
 ' #294 - Cut a 0.1.1 release and tag it on GitHub [doc] [cp]
@@ -37,11 +36,10 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
 ' #190 - Add test to verify all correct Chapter Verse Marker per book [test]
 ' #170 - Check doc and use line feed instead of paragraph mark throughout where verses are divided
 ' #151 - Add test for PrintCompactSectionLayoutInfo, number of one and two col sections, and print layout report file
-' #150 - Add module for free fonts setup and testing
-' #109 - Add test for CountAllEmptyParagraphs in doc, headers, footers, footnotes, and textboxes
-' #100 - Continue check multipage view from 300 for orphans of H2
+' #150 - Add module for free fonts setup and testing [idea]
+' #109 - Add test for CountAllEmptyParagraphs in doc, headers, footers, footnotes, and textboxes [test]
 ' #095 - Fix GetColorNameFromHex to match the chosen Bible RGB colors
-' #083 - Update name of Bible to Refined Word Bible (RWB) - Michael
+' #083 - Update name of Bible to Refined Word Bible (RWB) - Michael [idea]
 ' #070 - Word automatically adjusts smart quotes to match the context of the text
 '        Add test for Verse marker followed by any closing quote [test]
 ' #069 - Use WEB.doc to get a proper count of "'" and make sure RWB is correct
@@ -60,20 +58,22 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
 '           Christian Standard Bible (CSB):
 '               Utilizes smart quotes and nested quotations for direct speech.
 ' #060 - Add boolean test to check if any theme colors are used - Bible should use standard/defined colors, not themes [test]
-' #048 - Use https://www.bibleprotector.com/editions.htm for comparison of KJV with Pure Cambridge Edition
-' #047 - Research diff code that will display like GitHub for comparison with verse versions
-' #044 - Add extract to text file routine with book chapter reference - see web.txt from openbible.com as reference
-' #043 - Add extract to USFM routine
-' #042 - Add readme to aewordgit
-' #040 - Add figure headings to maps - use map vs fig?
-' #037 - Add updated maps in color
+' #048 - Use https://www.bibleprotector.com/editions.htm for comparison of KJV with Pure Cambridge Edition [idea]
+' #047 - Research diff code that will display like GitHub for comparison with verse versions [idea]
+' #044 - Add extract to text file routine with book chapter reference - see web.txt from openbible.com as reference [feat]
+' #043 - Add extract to USFM routine [feat]
+' #042 - Add readme to aewordgit [doc]
+' #040 - Add figure headings to maps - use map vs fig? [idea]
+' #037 - Add updated maps in color [feat]
 ' #035 - Add test for page numbers of h1 on odd or even pages [test]
-' #031 - Consider SILAS recommendation for adding pictures in text boxes to support USFM output
-' #029 - Add versions of usfm_sb.sty to the SILAS folder to be able to track progress
-' #024 - ExtractNumbersFromParagraph2 using DoEvents. Still unresponsive after Genesis 50, fifth para
+' #031 - Consider SILAS recommendation for adding pictures in text boxes to support USFM output [idea]
+' #029 - Add versions of usfm_sb.sty to the SILAS folder to be able to track progress [idea]
+' #024 - ExtractNumbersFromParagraph2 using DoEvents. Still unresponsive after Genesis 50, fifth para [bug]
 '====================================================================================================================================
 '
-    ' FIXED - #308 - Update all use of TestReportFlag to - If TestReportFlag And OneTest = 0
+    ' FIXED - #305 - Check header writing standard, vbnet vs. vba, use style ' ============== [cp] [clean]
+    ' [obso] #100 - Continue check multipage view from 300 for orphans of H2
+    ' FIXED - #308 - Update all use of TestReportFlag to -> If TestReportFlag And OneTest = 0
     ' FIXED - #307 - Remove bGoTo16, not needed with use of run single test [obso] [clean]
     ' FIXED - #306 - Add audit log from squash #274 [doc] [audit]
     ' FIXED - #279 - Add routine to define H2 style and reapply it in the project, add code header [impr] [code]

--- a/src/basChangeLogaeBibleClass.bas
+++ b/src/basChangeLogaeBibleClass.bas
@@ -73,67 +73,67 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
 '
     ' FIXED - #305 - Check header writing standard, vbnet vs. vba, use style ' ============== [cp] [clean]
     ' [obso] #100 - Continue check multipage view from 300 for orphans of H2
-    ' FIXED - #308 - Update all use of TestReportFlag to -> If TestReportFlag And OneTest = 0
+    ' FIXED - #308 - Update all use of TestReportFlag to -> If TestReportFlag And OneTest = 0 [bug]
     ' FIXED - #307 - Remove bGoTo16, not needed with use of run single test [obso] [clean]
     ' FIXED - #306 - Add audit log from squash #274 [doc] [audit]
     ' FIXED - #279 - Add routine to define H2 style and reapply it in the project, add code header [impr] [code]
 'Sq ' FIXED - #300 - Add md doc to outline a Compact Strategy for Squashed Audit Commits and reduce GitHub commit log spam
     ' FIXED - #304 - Add task type [wip] - it will prepend the task commits until replaced by FIXED
-    ' FIXED - #302 - Update PrintCompactSectionLayoutInfo to output in rpt folder, move to basTESTaeBibleTools and add doc header
+    ' FIXED - #302 - Update PrintCompactSectionLayoutInfo to output in rpt folder, move to basTESTaeBibleTools and add doc header [doc]
     ' FIXED - #301 - 999 AppendToFile should be "SKIPPED" [bug]
     ' FIXED - #274 - Fix output path so 'Style Usage Distribution.txt' goes to rpt folder, add code header [bug] [doc]
     ' FIXED - #299 - Add initial README and Bias Guard md files [doc] [cp]
-    ' FIXED - #298 - Use SSOT with Select Case statements for values such as num and verify with RUN_THE_TESTS
-    ' FIXED - #297 - Create file to hold Audits for Commit Log
-    ' FIXED - #296 - Add code for ValidateTaskInChangelogModule
-    ' FIXED - #286 - Update Heading 2 with DisableKeepLinesTogetherForHeading2
-    ' FIXED - #285 - Update Heading 2 with EnforceHeading2WidowOrphanControl
+    ' FIXED - #298 - Use SSOT with Select Case statements for values such as num and verify with RUN_THE_TESTS [impr]
+    ' FIXED - #297 - Create file to hold Audits for Commit Log [feat]
+    ' FIXED - #296 - Add code for ValidateTaskInChangelogModule [code]
+    ' FIXED - #286 - Update Heading 2 with DisableKeepLinesTogetherForHeading2 [doc]
+    ' FIXED - #285 - Update Heading 2 with EnforceHeading2WidowOrphanControl [doc]
     ' FIXED - #284 - Update Heading 2 KeepWithNext [audit]
     ' FIXED - #283 - Add code GetHeadingDefinitionsWithDescriptions to tools [audit]
     ' FIXED - #282 - Update guide with 'Example of Tags use for Audit Clarity' [doc]
-    ' FIXED - #278 - Use Single Source of Truth (SSOT) to fix multiple locations of array definition via MaxTests - see #273
+    ' FIXED - #278 - Use Single Source of Truth (SSOT) to fix multiple locations of array definition via MaxTests - see #273 [impr]
     ' FIXED - #277 - Define standard for types of "Tasks" to use with git commit messages [doc]
     ' FIXED - #273 - New error: Erl = 0 Error = 9 (Subscript out of range) in procedure RunBibleClassTests of Class BibleClass [bug]
-    ' FIXED - #276 - git mv TestReport to rpt/ and delete old version
-    ' FIXED - #275 - Create md folder for docs - md format, target github.io in future, git mv "Editorial Design and Style Guide.md"
-    ' FIXED - #272 - Add section on Architecture Overview: DOCM-Coupled Macro System
-    ' FIXED - #269 - All reports to be output to rpt folder
-    ' FIXED - #265 - Add SKIP option to RUN_THE_TESTS for slow tests. Return -1 in report log, and GetPassFail return SKIP!!!!
-    ' FIXED - #270 - Add test for SummarizeHeaderFooterAuditToFile
+    ' FIXED - #276 - git mv TestReport to rpt/ and delete old version [impr]
+    ' FIXED - #275 - Create md folder for docs - md format, target github.io in future, git mv "Editorial Design and Style Guide.md" [doc]
+    ' FIXED - #272 - Add section on Architecture Overview: DOCM-Coupled Macro System [doc]
+    ' FIXED - #269 - All reports to be output to rpt folder [feat]
+    ' FIXED - #265 - Add SKIP option to RUN_THE_TESTS for slow tests. Return -1 in report log, and GetPassFail return SKIP!!!! [feat]
+    ' FIXED - #270 - Add test for SummarizeHeaderFooterAuditToFile [test]
     ' FIXED - #264 - Add test for Style Usage Distribution [test]
     ' FIXED - #263 - Add CountAuditStyles_ToFile [test]
-    ' FIXED - #262 - Update code module names to match EDSG manifest
+    ' FIXED - #262 - Update code module names to match EDSG manifest [doc] [impr]
     ' FIXED - #261 - Add initial Editorial Design and Style Guide [doc]
-    ' FIXED - #257 - Update SmartPrefixRepairOnPage to give a count of Ascii 160 chars and any other e.g. hair space
-    ' FIXED - #260 - Update RepairWrappedVerseMarkers_MergedPrefix_ByColumnContext_SinglePage to give a count of Ascii 12 chars
-    ' FIXED - #258 - Add RunRepairWrappedVerseMarkers_Across_Pages_From to allow per page testing
+    ' FIXED - #257 - Update SmartPrefixRepairOnPage to give a count of Ascii 160 chars and any other e.g. hair space [impr]
+    ' FIXED - #260 - Update RepairWrappedVerseMarkers_MergedPrefix_ByColumnContext_SinglePage to give a count of Ascii 12 chars [impr]
+    ' FIXED - #258 - Add RunRepairWrappedVerseMarkers_Across_Pages_From to allow per page testing [impr]
     ' [obso] [regr] - #256 - Update SmartPrefixRepairOnPage to give a count of Ascii 12 chars
-    ' FIXED - #255 - Update SmartPrefixRepairOnPage for details on unprintable characters
-    ' FIXED - #254 - Add code for FindInvisibleFormFeeds_InPages
-    ' FIXED - #253 - Add code for LogExpandedMarkerContext
-    ' FIXED - #252 - Add code SmartPrefixRepairOnPage with Diagnostic Counter
-    ' FIXED - #251 - Add header to csv forecast output file
-    ' FIXED - #250 - Wire up dummy repair test with stats collection logic
-    ' FIXED - #249 - Add skeleton for StartRepairTimingSession
-    ' FIXED - #248 - Update repair tool for 10 pages
+    ' FIXED - #255 - Update SmartPrefixRepairOnPage for details on unprintable characters [impr]
+    ' FIXED - #254 - Add code for FindInvisibleFormFeeds_InPages [code]
+    ' FIXED - #253 - Add code for LogExpandedMarkerContext [code]
+    ' FIXED - #252 - Add code SmartPrefixRepairOnPage with Diagnostic Counter [code]
+    ' FIXED - #251 - Add header to csv forecast output file [feat]
+    ' FIXED - #250 - Wire up dummy repair test with stats collection logic [impr]
+    ' FIXED - #249 - Add skeleton for StartRepairTimingSession [impr]
+    ' FIXED - #248 - Update repair tool for 10 pages [impr]
     ' FIXED - #174 - Add tests for count tab para in headers and footers [test]
     ' FIXED - #088 - Add tests for Footnote Reference (in doc and footnote) to count those that are not bold with correct style [test]
     ' FIXED - #246 - Add test for styles using Liberation Sans Narrow [test]
-    ' FIXED - #245 - Add code Identify_ArialUnicodeMS_Paragraphs
-    ' FIXED - #244 - Unlink heading numbering, should not display Article... or Section... for H1 or H2
-    ' FIXED - #243 - Add code RedefinePictureCaptionStyle_NotoSans, step 3 of removing Lieration Sans Narrow reference
-    ' FIXED - #242 - Add code RedefineFootnoteNormalStyle_NotoSans, step 2 of removing Lieration Sans Narrow reference
-    ' FIXED - #241 - Add code RedefineFootnoteStyle_NotoSans, step 1 of removing Lieration Sans Narrow reference
-    ' FIXED - #240 - Update all repair code and add runner for checking 5 pages at a time
-    ' FIXED - #239 - Add routine ReportDigitAtCursor_Diagnostics_Expanded
+    ' FIXED - #245 - Add code Identify_ArialUnicodeMS_Paragraphs [code]
+    ' FIXED - #244 - Unlink heading numbering, should not display Article... or Section... for H1 or H2 [bug]
+    ' FIXED - #243 - Add code RedefinePictureCaptionStyle_NotoSans, step 3 of removing Lieration Sans Narrow reference [impr]
+    ' FIXED - #242 - Add code RedefineFootnoteNormalStyle_NotoSans, step 2 of removing Lieration Sans Narrow reference [impr]
+    ' FIXED - #241 - Add code RedefineFootnoteStyle_NotoSans, step 1 of removing Liberation Sans Narrow reference [impr]
+    ' FIXED - #240 - Update all repair code and add runner for checking 5 pages at a time [impr]
+    ' FIXED - #239 - Add routine ReportDigitAtCursor_Diagnostics_Expanded [code]
     ' FIXED - #238 - Update Chapter Verse marker repair tool with latest RepairWrappedVerseMarkerPrefixes_AdjacencyWithContext_Navigate
-    ' FIXED - #237 - Add diagnostic code to get character information around the cursor position
-    ' FIXED - #236 - Add routine to report Report Page Layout Metrics for a particular page
-    ' FIXED - #235 - Add code to repair "Chapter Verse marker" per page, add vbCr if on column edge with space before, defrag as needed
+    ' FIXED - #237 - Add diagnostic code to get character information around the cursor position [code]
+    ' FIXED - #236 - Add routine to report Report Page Layout Metrics for a particular page [feat]
+    ' FIXED - #235 - Add code to repair "Chapter Verse marker" per page, add vbCr if on column edge with space before, defrag as needed [impr]
     ' FIXED - #234 - Add test to count footers that have only a tab character [test]
     ' FIXED - #212 - Add test for CountFindNotEmphasisBlack = 0 and CountFindNotEmphasisRed = 0 when all have been set [test]
     ' FIXED - #233 - Add test for CountParagraphMarks_CalibriDarkRed [test]
-    ' FIXED - #232 - Add word version into to output and test report
+    ' FIXED - #232 - Add word version into to output and test report [doc]
 ' 20250719 - v010
     ' FIXED - #148 - Add version info to TestReport output
     ' FIXED - #231 - Reapply explicit formatting (Segoe UI 8, Bold, Blue, Superscript) for Footnote Reference, Fix for #230

--- a/src/basChangeLogaeBibleClass.bas
+++ b/src/basChangeLogaeBibleClass.bas
@@ -14,7 +14,6 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
 ' #306 -
 ' #305 -
 ' #303 - Fix single RUN_THE_TESTS(x) so it does not run AppendToFile and kill the full report [bug]
-' #300 - Add md doc to outline a Compact Strategy for Squashed Audit Commits and reduce GitHub commit log spam
 ' #295 - Verify use of late binding in all code base so there is no need to set references [code]
 ' #294 - Cut a 0.1.1 release and tag it on GitHub [doc] [cp]
 ' #293 - Add md doc 'Bias Guard' to reduce hallucination (h13n) [doc] [cp]
@@ -26,7 +25,6 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
 ' #287 - Update labels for Tasks and retroactively link to historic issues [doc] [impr] [cp]
 ' #281 - Explain methodology of Test Driven Development [doc]
 ' #280 - Add test to count H2, "How many Chapters are in the Bible", Copilot -> 1,189
-' #279 - Add routine to define H2 style and reapply it in the project
 ' #271 - Add routine headers for targeting github.io docs in future [doc]
 ' #268 - Timings of TestReport to go in csv log file with session ID for each run
 ' #267 - Add code for CompleteAuditPageLayout
@@ -78,10 +76,12 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
 ' #024 - ExtractNumbersFromParagraph2 using DoEvents. Still unresponsive after Genesis 50, fifth para
 '====================================================================================================================================
 '
+    ' FIXED - #279 - Add routine to define H2 style and reapply it in the project, add code header [impr] [code]
+'Sq ' FIXED - #300 - Add md doc to outline a Compact Strategy for Squashed Audit Commits and reduce GitHub commit log spam
     ' FIXED - #304 - Add task type [wip] - it will prepend the task commits until replaced by FIXED
     ' FIXED - #302 - Update PrintCompactSectionLayoutInfo to output in rpt folder, move to basTESTaeBibleTools and add doc header
     ' FIXED - #301 - 999 AppendToFile should be "SKIPPED" [bug]
-'Sq ' FIXED - #274 - Fix output path so 'Style Usage Distribution.txt' goes to rpt folder, add code header [bug] [doc]
+    ' FIXED - #274 - Fix output path so 'Style Usage Distribution.txt' goes to rpt folder, add code header [bug] [doc]
     ' FIXED - #299 - Add initial README and Bias Guard md files [doc] [cp]
     ' FIXED - #298 - Use SSOT with Select Case statements for values such as num and verify with RUN_THE_TESTS
     ' FIXED - #297 - Create file to hold Audits for Commit Log

--- a/src/basChangeLogaeBibleClass.bas
+++ b/src/basChangeLogaeBibleClass.bas
@@ -6,32 +6,32 @@ Option Private Module
 Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
 
 '====================================================================================================================================
-' Tasks: [doc] [test] [bug] [perf] [audit] [disc] [feat] [idea] [impr] [flow] [cp] [code] [wip]
+' Tasks: [doc] [test] [bug] [perf] [audit] [disc] [feat] [idea] [impr] [flow] [cp] [code] [wip] [clean] [obso] [regr]
 ' #310 -
 ' #309 -
 ' #308 -
 ' #307 -
-' #306 -
-' #305 -
+' #306 - Add audit log from squash #274 [doc] [audit]
+' #305 - Check header writing standard, vbnet vs. vba [cp] [clean]
 ' #303 - Fix single RUN_THE_TESTS(x) so it does not run AppendToFile and kill the full report [bug]
 ' #295 - Verify use of late binding in all code base so there is no need to set references [code]
 ' #294 - Cut a 0.1.1 release and tag it on GitHub [doc] [cp]
 ' #293 - Add md doc 'Bias Guard' to reduce hallucination (h13n) [doc] [cp]
 ' #292 - Add md doc describing use of Copilot for documentation creation [doc] [cp]
-' #291 - Add md doc that shows clearly the workflow for GitHub integration [doc] [flow]
-' #290 - Add test for count of H1 with style
-' #289 - Add test for count of H2 with style
+' #291 - See #300 - Add md doc that shows clearly the workflow for GitHub integration [doc] [flow]
+' #290 - Add test for count of H1 with style [test]
+' #289 - Add test for count of H2 with style [test]
 ' #288 - Create md doc file describing use of Tasks labels [doc]
 ' #287 - Update labels for Tasks and retroactively link to historic issues [doc] [impr] [cp]
 ' #281 - Explain methodology of Test Driven Development [doc]
 ' #280 - Add test to count H2, "How many Chapters are in the Bible", Copilot -> 1,189
-' #271 - Add routine headers for targeting github.io docs in future [doc]
-' #268 - Timings of TestReport to go in csv log file with session ID for each run
-' #267 - Add code for CompleteAuditPageLayout
+' #271 - Add routine headers for targeting github.io docs in future [doc] [cp]
+' #268 - Timings of TestReport to go in csv log file with session ID for each run [impr]
+' #267 - Add code for CompleteAuditPageLayout [code]
 ' #266 - Create design for new routine CompleteAuditPageLayout in md format - Pre, Scan, Post [doc]
-' #259 - Remove old code that regressed
-' #247 - see #279 - Add code to define H1 and H2 exactly and apply to all
-' #226 - Update CompareHeading1sWithShowHideToggle to use CheckShowHideStatus
+' #259 - Remove old code that regressed [clean]
+' #247 - see #279 - Add code to define H1 and H2 exactly and apply to all [code] [doc] [impr]
+' #226 - Update CompareHeading1sWithShowHideToggle to use CheckShowHideStatus [impr]
 ' #221 - Add test that will compare DOCVARIABLEs with result of PrintHeading1sByLogicalPage for page verification [test]
 ' #214 - Fix contents page to include all bookmarked Heading_01+ numbers
 ' #206 - Add test for all H1 pages to verify no paragraphs have indent setting [test]
@@ -107,7 +107,7 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
     ' FIXED - #257 - Update SmartPrefixRepairOnPage to give a count of Ascii 160 chars and any other e.g. hair space
     ' FIXED - #260 - Update RepairWrappedVerseMarkers_MergedPrefix_ByColumnContext_SinglePage to give a count of Ascii 12 chars
     ' FIXED - #258 - Add RunRepairWrappedVerseMarkers_Across_Pages_From to allow per page testing
-    ' OBSOLETE REGRESSION - #256 - Update SmartPrefixRepairOnPage to give a count of Ascii 12 chars
+    ' [obso] [regr] - #256 - Update SmartPrefixRepairOnPage to give a count of Ascii 12 chars
     ' FIXED - #255 - Update SmartPrefixRepairOnPage for details on unprintable characters
     ' FIXED - #254 - Add code for FindInvisibleFormFeeds_InPages
     ' FIXED - #253 - Add code for LogExpandedMarkerContext
@@ -137,7 +137,7 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
 ' 20250719 - v010
     ' FIXED - #148 - Add version info to TestReport output
     ' FIXED - #231 - Reapply explicit formatting (Segoe UI 8, Bold, Blue, Superscript) for Footnote Reference, Fix for #230
-    ' OBSOLETE - #230 - Add code to fix Footnote Reference by reapplying style
+    ' [obso] - #230 - Add code to fix Footnote Reference by reapplying style
     ' FIXED - #225 - Add code to verify Show/Hide is True when tests are run else stop with error message
     ' FIXED - #229 - Add code to verify all necessary settings of Word are enabled - basWordSettingsDiagnostic
     ' FIXED - #228 - Abort tests if Show/Hide is not set
@@ -171,10 +171,10 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
     ' FIXED - #207 - Check H1 pages for consistent use of superscript as in 2nd etc.
     ' FIXED - #106 - Fix H1 pages to use line feed in text as appropriate
     ' FIXED - #205 - Goto next book on next- button click in constant cycle (Note: getEnabled is flaky so do not use for now)
-    ' Updated - Fixed - #204 - Add next- book button to ribbon : Refer also to customUI14backupRWB.xml
-    ' OBSOLETE - #157 - Add Word OT DOCVARIABLEs, Ctrl + F9 field brackets { }, right-click the field, select Update Field - verify
+    ' [impr] - FIXED - #204 - Add next- book button to ribbon : Refer also to customUI14backupRWB.xml
+    ' [obso] - #157 - Add Word OT DOCVARIABLEs, Ctrl + F9 field brackets { }, right-click the field, select Update Field - verify
     ' FIXED - #045 - Test call to SILAS from ribbon using customUI14.xml OnHelloWorldButtonClick routine
-    ' OBSOLETE - #041 - Add auto-generated TOC for maps : auto gen too slow
+    ' [obso] - #041 - Add auto-generated TOC for maps : auto gen too slow
     ' FIXED - See #203 - #160 - Add DOCVARIABLEs for all New Testament books
     ' FIXED - #203 - Add DOCVARIABLEs for New Testament
     ' FIXED - #202 - Move GoToVerseSBL to ribbon module
@@ -231,7 +231,7 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
     ' FIXED - #123 - Add file TestReport.txt output additional to console result for GitHub tracking
     ' FIXED - #046 - Update style of cv marker to be smaller than Verse marker
     ' FIXED - #082 - Fix Word paragraph style so minimal empty paragraphs are needed
-    ' OBSOLETE - #039 - Replace manual TOC with auto-generated version (this is too slow)
+    ' [obso] - #039 - Replace manual TOC with auto-generated version (this is too slow)
     ' FIXED - #141 - Update UTF8bom-Template.txt with multiple language sample of "Hello, World!" ala C style, plus phonetics
 ' 20250420 - v008
     ' FIXED - #140 - Set version info as global variables and assign in Class_Initialize
@@ -279,7 +279,7 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
     ' FIXED - #098 - Add test to count number of Footnote References [test]
     ' FIXED - #096 - Add test for count/delete empty para before H2, related #084 [test]
     ' FIXED - #084 - Update Heading 2 style paragraph to before 12 pt and delete the previous empty para
-    ' OBSOLETE - #017 - Add optional variant to aeBibleClass for indicating Copy (x) under testing
+    ' [obso] - #017 - Add optional variant to aeBibleClass for indicating Copy (x) under testing
     ' FIXED - #094 - Add test to List And Count Font Colors, and print the name from a conversion function
     ' FIXED - #090 - Work through Count Spaces After Footnotes debug output and fix as appropriate, split from ch/v numbers
     ' FIXED - #016 - Add function to print pass/fail based on comparing Result with Expected
@@ -319,13 +319,13 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
 '           Closing single quote: Alt + 0146    ' FIXED - #064 - When bTimeAllTests is True it does not show total time
     ' FIXED - #063 - Update RunTest so it will allow a range of tests to be run (15 tests range)
     ' FIXED - #065 - Add module basTESTaeBibleTools for routines that are useful to tests outside of the class
-    ' OBSOLETE - Replaced with #062 - #036 - Add test for h1 pages that have heading
+    ' [obso] - Replaced with #062 - #036 - Add test for h1 pages that have heading
     ' FIXED - #062 - Add test for Sections With Different FirstPage selected [test]
     ' FIXED - #055 - Update RunTest so expected gets values from Expected string array
     ' FIXED - #061 - Add variant get array function of Expected to aeBibleClass and initialize with RunTest expected values
     ' FIXED - #059 - Add boolean flag to class to turn off timing for all tests
     ' FIXED - #058 - Add timer to each test and output total runtime of all tests
-    ' OBSOLETE - #054 - Add string array Expected to aeBibleClass and initialize with RunTest expected values
+    ' [obso] - #054 - Add string array Expected to aeBibleClass and initialize with RunTest expected values
     ' FIXED - #056 - Add test for white paragraph marks [test]
 ' 20250323 - v005
     ' FIXED - #052 - Add vba message box with yes/no choice to continue or stop for RunTest error
@@ -333,7 +333,7 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
     ' FIXED - #050 - Error Test num = 11 Function RunTest - need to fix it [test]
     ' FIXED - #049 - Add test for count of empty paragraphs with no theme color, wdColorAutomatic = -1 [test]
     ' FIXED - #025 (Ref #034) - Check if para is continuous break or section break next page then read the next para
-    ' OBSOLETE - #027 - Create SILAS dir and add Normal.dot then extract the code to GitHub - code provided by Jim
+    ' [obso] - #027 - Create SILAS dir and add Normal.dot then extract the code to GitHub - code provided by Jim
     ' FIXED - #034 - Add routine to count of all paragraphs types
     ' FIXED - #033 - Add Hello World custom menu tab as example for ribbon integration
     ' FIXED - #032 - Revert RunTest (12) as form feeds are needed in page and section breaks

--- a/src/basChangeLogaeBibleClass.bas
+++ b/src/basChangeLogaeBibleClass.bas
@@ -11,7 +11,6 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
 ' #309 -
 ' #308 -
 ' #307 -
-' #306 - Add audit log from squash #274 [doc] [audit]
 ' #305 - Check header writing standard, vbnet vs. vba [cp] [clean]
 ' #303 - Fix single RUN_THE_TESTS(x) so it does not run AppendToFile and kill the full report [bug]
 ' #295 - Verify use of late binding in all code base so there is no need to set references [code]
@@ -76,6 +75,7 @@ Public Const MODULE_NOT_EMPTY_DUMMY As String = vbNullString
 ' #024 - ExtractNumbersFromParagraph2 using DoEvents. Still unresponsive after Genesis 50, fifth para
 '====================================================================================================================================
 '
+    ' FIXED - #306 - Add audit log from squash #274 [doc] [audit]
     ' FIXED - #279 - Add routine to define H2 style and reapply it in the project, add code header [impr] [code]
 'Sq ' FIXED - #300 - Add md doc to outline a Compact Strategy for Squashed Audit Commits and reduce GitHub commit log spam
     ' FIXED - #304 - Add task type [wip] - it will prepend the task commits until replaced by FIXED

--- a/src/basTESTaeBibleTools.bas
+++ b/src/basTESTaeBibleTools.bas
@@ -1459,37 +1459,43 @@ Sub GetHeadingDefinitionsWithDescriptions()
     Next styleName
 End Sub
 
-Sub UpdateHeading2KeepWithNext()
+' ======================================================================
+' Macro Name   : CreateDefinitionForH2
+' Purpose      : Enforces layout and paragraph rules for Heading 2 style.
+'                - Enables KeepWithNext on Heading 2 paragraph style.
+'                - Applies WidowControl to each Heading 2 paragraph.
+'                - Explicitly disables KeepTogether to prevent override.
+' Audit Notes  : Logs all repair actions to Immediate Window.
+'                Does NOT alter any content, punctuation, or quotes.
+'                Applies paragraph-level enforcement only where style = "Heading 2"
+' Safety Level : Editorial-safe. No deletions or format coercion.
+' Last Updated : [add date]
+' Author       : [optional]
+' ======================================================================
+Sub CreateDefinitionForH2()
+    ' Update Heading 2 Keep With Next
     Dim s As style
     Set s = ActiveDocument.Styles("Heading 2")
     
     ' Apply KeepWithNext to paragraph formatting
     s.ParagraphFormat.KeepWithNext = True
-
     Debug.Print "Heading 2 style updated: KeepWithNext = True"
-End Sub
 
-Sub EnforceHeading2ParagraphWidowOrphan()
+    ' Enforce Heading 2 Paragraph Widow Orphan
+    ' Disable KeepLines Together For Heading 2
     Dim para As paragraph
     For Each para In ActiveDocument.paragraphs
         If para.style = ActiveDocument.Styles("Heading 2") Then '
             With para
                 .WidowControl = True    ' enforces both widow and orphan control for that paragraph
                 '.OrphanControl = True - Not needed,
+                para.KeepTogether = False
             End With
         End If
     Next para
     Debug.Print "[repair] Widow/Orphan enforced at paragraph level for Heading 2"
-End Sub
-
-Sub DisableKeepLinesTogetherForHeading2()
-    Dim para As paragraph
-    For Each para In ActiveDocument.paragraphs
-        If para.style = ActiveDocument.Styles("Heading 2") Then
-            para.KeepTogether = False
-        End If
-    Next para
     Debug.Print "[repair] KeepLinesTogether disabled for Heading 2"
+
 End Sub
 
 '==============================================

--- a/src/basTESTaeBibleTools.bas
+++ b/src/basTESTaeBibleTools.bas
@@ -163,6 +163,21 @@ Function GetColorNameFromHex(hexColor As String) As String
     GetColorNameFromHex = colorName
 End Function
 
+' =================================================================================================
+' Subroutine:   ListAndCountFontColors
+' Purpose:      Iterates over all words in the active Word document, extracts the RGB font color,
+'               and tallies occurrences per unique color. Outputs formatted results to the console
+'               including color name via GetColorNameFromHex.
+' Inputs:       None (operates on ActiveDocument)
+' Outputs:      Debug.Print output of RGB, Hex, count, and resolved color name
+' Dependencies: Requires GetColorNameFromHex(hexColor As String) function to be present
+' Author:       Peter
+' Last Updated: 2025-08-02
+' Notes:        - Hex keys are zero-padded for consistency
+'               - Font.Color property is bitmasked and decomposed manually
+'               - Does not account for style inheritance or partial selections
+'               - Expansion possible to handle suffix-aware grouping or paragraph-level aggregation
+' =================================================================================================
 Sub ListAndCountFontColors()
     Dim rng As range
     Dim colorDict As Object

--- a/src/basTESTaeBibleTools.bas
+++ b/src/basTESTaeBibleTools.bas
@@ -112,6 +112,17 @@ Sub DeleteCustomUIXML()
     MsgBox "CustomUI XML parts deleted successfully!"
 End Sub
 
+' ========================================================================================
+' Function:     GetColorNameFromHex
+' Purpose:      Translates a hexadecimal color string (e.g., "#FF0000") into a human-readable
+'               color name. Useful for diagnostics, audit logs, or UI labeling in scripts.
+' Inputs:       hexColor [String] - A color code in hexadecimal format, e.g., "#FF0000"
+' Returns:      [String] - The corresponding color name, or "Unknown Color" if not matched.
+' Author:       Peter
+' Last Updated: 2025-08-02
+' Notes:        - Hex code is normalized to uppercase for consistent comparison.
+'               - Expand CASE block as needed for additional named colors.
+' ========================================================================================
 Function GetColorNameFromHex(hexColor As String) As String
     Dim colorName As String
     
@@ -1386,7 +1397,7 @@ Sub ReapplyTheFootersToAllFooters()
     Debug.Print "=== Style Reapplication Complete ==="
 End Sub
 
-'------------------------------------------------------------------------------
+' =============================================================================
 ' Macro Name : GetHeadingDefinitionsWithDescriptions
 ' Author     : Peter + Copilot
 ' Description:
@@ -1406,7 +1417,7 @@ End Sub
 '   - Export to CSV or Markdown
 '   - Include suffix tracking, style inheritance, or font audit flags
 '   - Integrate session-aware tracking or timing metrics
-'------------------------------------------------------------------------------
+' =============================================================================
 Sub GetHeadingDefinitionsWithDescriptions()
     Dim headingStyles As Variant
     headingStyles = Array("Heading 1", "Heading 2")


### PR DESCRIPTION
FIXED - #309 - Add code to scan modules in .docm to flag early-bound object declarations [code]
FIXED - #303 - Fix single RUN_THE_TESTS(x) so it does not run AppendToFile and kill the full report [bug]
FIXED - #305 - Check header writing standard, vbnet vs. vba, use style ' ============== [cp] [clean]
[obso] #100 - Continue check multipage view from 300 for orphans of H2
FIXED - #308 - Update all use of TestReportFlag to -> If TestReportFlag And OneTest = 0 [bug]
FIXED - #307 - Remove bGoTo16, not needed with use of run single test [obso] [clean]
FIXED - #306 - Add audit log from squash #274 [doc] [audit]
FIXED - #279 - Add routine to define H2 style and reapply it in the project, add code header [impr] [code]
FIXED - #300 - Add md doc to outline a Compact Strategy for Squashed Audit Commits and reduce GitHub commit log spam